### PR TITLE
Actualizar enlace de LinkedIn y extender fecha del contador regresivo

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 					<i class="fa fa-github"></i>
                 </a>
                 
-                <a href="https://www.linkedin.com/in/christian-stuart-grimberg-12188632/" class="flex-c-m size5 bg5 how1 trans-04 m-r-5" target="_blank">
+                <a href="https://www.linkedin.com/in/christiangrimberg/" class="flex-c-m size5 bg5 how1 trans-04 m-r-5" target="_blank">
                     <i class="fa fa-linkedin"></i>
                 </a>
 
@@ -118,10 +118,10 @@
 		$('.cd100').countdown100({
 			/*Set Endtime here*/
 			/*Endtime must be > current time*/
-			endtimeYear: 2019,
-			endtimeMonth: 11,
-			endtimeDate: 25,
-			endtimeHours: 8,
+			endtimeYear: 2021,
+			endtimeMonth: 1,
+			endtimeDate: 1,
+			endtimeHours: 0,
 			endtimeMinutes: 0,
 			endtimeSeconds: 0,
 			timeZone: "America/Argentina/Buenos_Aires" 


### PR DESCRIPTION
## Resumen

Este PR agrupa dos cambios en `index.html`:

1. **Actualizar el enlace de LinkedIn** en la sección de redes sociales para apuntar al slug canónico actual del perfil (`/in/christiangrimberg/`), reemplazando el slug antiguo (`/in/christian-stuart-grimberg-12188632/`).
2. **Extender la fecha objetivo del contador regresivo** (countdown) de **25/11/2019 08:00** a **01/01/2021 00:00** (timezone `America/Argentina/Buenos_Aires`).

El primer cambio cierra el issue #1. El segundo es un ajuste colateral de mantenimiento para que el contador no quedara vencido al momento del merge.

## Cambios

```
index.html | 5 ++---
 1 file changed, 2 insertions(+), 3 deletions(-)
```

Detalle por bloque:

- Bloque "LinkedIn": `-1 / +1` (atributo `href`).
- Bloque "Countdown": `-4 / +4` (`endtimeYear/Month/Date/Hours` → 2021/1/1/0).

## Notas

- Ambos cambios viven en el mismo archivo (`index.html`) y al momento del PR no se contaba con un sistema de templates Liquid/Jekyll para aislarlos, por lo que se agruparon en un único PR.
- El `target="_blank"` del enlace de LinkedIn ya estaba presente en el markup y no requirió cambios.
- Issue cerrado: #1.
