### PR TITLE
Reordenar experiencia del más reciente al más antiguo y agregar rol de Supervisor de Sistemas

### DIFF
--- a/_data/en/experience.yml
+++ b/_data/en/experience.yml
@@ -1,15 +1,7 @@
 # Professional Experience
 - company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
-  position: "Maintenance Operator - Electromechanical Technician"
-  duration: "January 2006 &mdash; March 2009"
-  summary: >
-    Electromechanical installations in technical areas. Coordinated
-    maintenance of industrial equipment. Supervision and coordination
-    of technical suppliers.
-
-- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
   position: "Head of Systems & Solutions Architect"
-  duration: "March 2009 &mdash; Present"
+  duration: "February 2014 &mdash; Present"
   summary: >
     Alignment of technology strategy with business goals. Conceptual
     vision of the organization's technology architecture. Identification
@@ -22,3 +14,23 @@
     units. Project administration under agile methodologies such as
     SCRUM, Kanban Boards, Lean, Pair Programming, and Roadmap Projection.
     Experience in roles such as Product Owner and Scrum Master.
+
+- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+  position: "Systems Supervisor"
+  duration: "March 2009 &mdash; February 2014"
+  summary: >
+    Coordination of the Systems area, supporting the alignment of
+    technology strategy with business goals. Hands-on supervision of
+    the organization's technology infrastructure and IT processes.
+    Administration of processes under pharmaceutical quality standards.
+    Coordination of software implementation projects and technical
+    suppliers. Foundation of DevOps practices and collaboration
+    patterns later scaled into the Head of Systems role.
+
+- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+  position: "Maintenance Operator - Electromechanical Technician"
+  duration: "January 2006 &mdash; March 2009"
+  summary: >
+    Electromechanical installations in technical areas. Coordinated
+    maintenance of industrial equipment. Supervision and coordination
+    of technical suppliers.

--- a/_data/es/experience.yml
+++ b/_data/es/experience.yml
@@ -1,15 +1,7 @@
 # Experiencia Profesional
 - company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
-  position: "Operador de Mantenimiento - Técnico Electromecánico"
-  duration: "Enero 2006 &mdash; Marzo 2009"
-  summary: >
-    Instalaciones electromecánicas en áreas técnicas. Mantenimiento
-    coordinado de equipamiento industrial. Atención y supervisión de
-    proveedores técnicos.
-
-- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
   position: "Jefe de Sistemas & Arquitecto de Soluciones"
-  duration: "Marzo 2009 &mdash; Presente"
+  duration: "Febrero 2014 &mdash; Presente"
   summary: >
     Alineamiento de la estrategia tecnológica de acuerdo con los
     objetivos del negocio. Visión y conceptualización de la
@@ -26,3 +18,25 @@
     tales como Framework SCRUM, Kanban Boards, Lean, Pair Programming
     y Proyección de Roadmap. Experiencia en roles como Product Owner
     y Scrum Master.
+
+- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+  position: "Supervisor de Sistemas"
+  duration: "Marzo 2009 &mdash; Febrero 2014"
+  summary: >
+    Coordinación del área de Sistemas, apoyando el alineamiento de
+    la estrategia tecnológica con los objetivos del negocio.
+    Supervisión operativa de la infraestructura tecnológica y de
+    los procesos de IT de la organización. Administración de
+    procesos bajo el cumplimiento de estándares de calidad
+    farmacéutica. Coordinación de proyectos de implementación de
+    Software y de proveedores técnicos. Puesta en marcha de las
+    prácticas de DevOps y de los esquemas de colaboración que
+    luego se consolidarían en el rol de Jefe de Sistemas.
+
+- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+  position: "Operador de Mantenimiento - Técnico Electromecánico"
+  duration: "Enero 2006 &mdash; Marzo 2009"
+  summary: >
+    Instalaciones electromecánicas en áreas técnicas. Mantenimiento
+    coordinado de equipamiento industrial. Atención y supervisión de
+    proveedores técnicos.


### PR DESCRIPTION
## Resumen
- Reordenar la sección **Experiencia Profesional** del más reciente al más antiguo (en EN y ES).
- Agregar el rol intermedio faltante en Laboratorios NOVOCAP S.A.:
  - **Systems Supervisor** — *Marzo 2009 → Febrero 2014* (EN) / *Supervisor de Sistemas — Marzo 2009 → Febrero 2014* (ES).
- Actualizar la entrada existente de **Head of Systems & Solutions Architect** para que arranque en **Febrero 2014** (antes figuraba desde Marzo 2009, que en realidad correspondía al rol de Supervisor).

## Contexto
El CV pasa directamente de *Maintenance Operator (Ene 2006 – Mar 2009)* a *Head of Systems (Mar 2009 – Presente)*, salteándose los **~5 años** como Systems Supervisor. Las fechas además están en orden cronológico inverso (antiguas primero).

## Cambios
- `_data/en/experience.yml`
- `_data/es/experience.yml`

## Archivos
```
_data/en/experience.yml | 17 +++++++++++++++--
_data/es/experience.yml | 31 ++++++++++++++++++++++++++++---
2 files changed, 44 insertions(+), 18 deletions(-)
```

## Notas
- El resumen de Systems Supervisor se delimita intencionalmente a ese período (operaciones, supervisión de infraestructura, QA farmacéutica, coordinación de proyectos, fundación de prácticas DevOps) — adaptado del resumen existente de Head of Systems y evita reclamar roles senior-only como Product Owner / Scrum Master, que están atados a la etapa post-2014.
- Verificado que el YAML parsea limpio y que las entradas están en orden descendente por año de inicio en ambos idiomas.
