### PR TITLE
Agregar sección de Educación Continua con 16 cursos seleccionados + badge MAP

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ resume_looking_for_work: ""
 # Decide which sections to use
 resume_section_experience: true
 resume_section_education: true
+resume_section_continuing_education: true
 resume_section_projects: true
 resume_section_skills: true
 resume_section_recognition: true

--- a/_data/en/continuing-education.yml
+++ b/_data/en/continuing-education.yml
@@ -1,0 +1,112 @@
+# Continuing Education — curated subset (16 of 95 LinkedIn credentials)
+# Selection criteria: official certifications & vendor badges, pharmaceutical
+# industry specialization, and long-form / leadership programs.
+# Ordered newest-first by year of completion.
+# Full list: https://www.linkedin.com/in/christiangrimberg/details/certifications/
+
+# --- 2023 ---
+- name: "Introduction to ITSM"
+  organization: "Atlassian"
+  year: "2023"
+  summary: >-
+    Foundational training in IT Service Management practices and
+    Atlassian's approach.
+
+- name: "Carrera de Data Analytics"
+  organization: "Coderhouse"
+  year: "2023"
+  summary: >-
+    Full Data Analytics career path (Excel, SQL, BI tools, statistics).
+
+- name: "Todo lo que debería saber sobre Integridad de Datos"
+  organization: "JENCK"
+  year: "2023"
+  summary: >-
+    Pharmaceutical data integrity fundamentals.
+
+- name: "Mantenimiento del estado de control"
+  organization: "OQOTECH"
+  year: "2023"
+  summary: >-
+    Control state maintenance in computerized pharmaceutical systems.
+
+- name: "Análisis de requisitos y enfoque de validación para los Sistemas Informatizados"
+  organization: "OQOTECH"
+  year: "2023"
+  summary: >-
+    Requirements analysis and validation approach for computerized systems.
+
+# --- 2021 ---
+- name: "Azure DevOps Professional Training"
+  organization: "MUG Asociación Civil (Microsoft User Group Argentina)"
+  year: "2021"
+  summary: >-
+    Professional training on Azure DevOps services and DevOps practices.
+
+- name: "Workshop Go desde cero"
+  organization: "Microsoft User Group Argentina"
+  year: "2021"
+  summary: >-
+    Hands-on workshop introducing the Go programming language.
+
+# --- 2020 ---
+- name: "Optimización de procesos productivos a través de sistemas informáticos"
+  organization: "SAFYBI"
+  year: "2020"
+  summary: >-
+    Optimization of pharmaceutical production processes through IT systems.
+
+# --- 2019 ---
+- name: "Integridad de Datos"
+  organization: "cGMPdoc"
+  year: "2019"
+  summary: >-
+    Data integrity principles under cGMP regulatory frameworks.
+
+- name: "Ciclo de Vida de Sistemas Computarizados"
+  organization: "cGMPdoc"
+  year: "2019"
+  summary: >-
+    Computerized system validation lifecycle (GAMP 5-aligned).
+
+- name: "Formación de Auditores"
+  organization: "cGMPdoc"
+  year: "2019"
+  summary: >-
+    Auditor training for GxP-regulated computerized systems.
+
+# --- 2014 ---
+- name: "Master en Sistemas"
+  organization: "CentralTECH"
+  year: "2014"
+  summary: >-
+    Comprehensive systems master program covering infrastructure,
+    networking, and administration.
+
+# --- 2013 ---
+- name: "Microsoft Active Professional"
+  organization: "Microsoft"
+  year: "2013"
+  summary: >-
+    Community recognition for active participation in Microsoft technical
+    communities and events.
+
+# --- 2012 ---
+- name: "Programa de Liderazgo de Equipos de Trabajo"
+  organization: "IDEA ARG"
+  year: "2012"
+  summary: >-
+    Executive leadership and team management program.
+
+# --- 2011 ---
+- name: "Oracle 11g DBA"
+  organization: "CentralTECH"
+  year: "2011"
+  summary: >-
+    Database administration training for Oracle 11g.
+
+- name: "Enterprise Asterisk Administrator"
+  organization: "CentralTECH"
+  year: "2011"
+  summary: >-
+    Administration of Asterisk-based enterprise telephony systems.

--- a/_data/en/recognitions.yml
+++ b/_data/en/recognitions.yml
@@ -12,3 +12,10 @@
   summary: >
     Demonstrated understanding of security, compliance, and identity
     concepts across Microsoft cloud services.
+
+- award: "Microsoft Active Professional"
+  organization: Microsoft
+  year: "2013"
+  summary: >-
+    Community recognition for active participation in Microsoft
+    technical communities and events.

--- a/_data/en/strings.yml
+++ b/_data/en/strings.yml
@@ -8,6 +8,7 @@ not_looking: "I'm not looking for work right now."
 # Section headers
 section_experience: "Professional Experience"
 section_education: "Education"
+section_continuing_education: "Continuing Education & Specialized Training"
 section_projects: "Featured Projects"
 section_skills: "Technical Skills"
 section_recognition: "Certifications & Recognition"

--- a/_data/es/continuing-education.yml
+++ b/_data/es/continuing-education.yml
@@ -1,0 +1,121 @@
+# Formación Continua — subset curado (16 de 95 credenciales de LinkedIn)
+# Criterio de selección: certificaciones oficiales y badges de vendors,
+# formación especializada en industria farmacéutica, y programas largos
+# de liderazgo. Ordenado del más reciente al más antiguo por año.
+# Lista completa:
+# https://www.linkedin.com/in/christiangrimberg/details/certifications/
+
+# --- 2023 ---
+- name: "Introduction to ITSM"
+  organization: "Atlassian"
+  year: "2023"
+  summary: >-
+    Formación fundamental en prácticas de IT Service Management y el
+    enfoque de Atlassian.
+
+- name: "Carrera de Data Analytics"
+  organization: "Coderhouse"
+  year: "2023"
+  summary: >-
+    Carrera completa de Data Analytics (Excel, SQL, herramientas de BI,
+    estadística).
+
+- name: "Todo lo que debería saber sobre Integridad de Datos"
+  organization: "JENCK"
+  year: "2023"
+  summary: >-
+    Fundamentos de integridad de datos en la industria farmacéutica.
+
+- name: "Mantenimiento del estado de control"
+  organization: "OQOTECH"
+  year: "2023"
+  summary: >-
+    Mantenimiento del estado de control en sistemas farmacéuticos
+    computarizados.
+
+- name: "Análisis de requisitos y enfoque de validación para los Sistemas Informatizados"
+  organization: "OQOTECH"
+  year: "2023"
+  summary: >-
+    Análisis de requisitos y enfoque de validación para sistemas
+    informatizados.
+
+# --- 2021 ---
+- name: "Azure DevOps Professional Training"
+  organization: "MUG Asociación Civil (Microsoft User Group Argentina)"
+  year: "2021"
+  summary: >-
+    Capacitación profesional sobre servicios de Azure DevOps y
+    prácticas DevOps.
+
+- name: "Workshop Go desde cero"
+  organization: "Microsoft User Group Argentina"
+  year: "2021"
+  summary: >-
+    Workshop práctico de introducción al lenguaje de programación Go.
+
+# --- 2020 ---
+- name: "Optimización de procesos productivos a través de sistemas informáticos"
+  organization: "SAFYBI"
+  year: "2020"
+  summary: >-
+    Optimización de procesos productivos de la industria farmacéutica
+    mediante sistemas informáticos.
+
+# --- 2019 ---
+- name: "Integridad de Datos"
+  organization: "cGMPdoc"
+  year: "2019"
+  summary: >-
+    Principios de integridad de datos bajo marcos regulatorios cGMP.
+
+- name: "Ciclo de Vida de Sistemas Computarizados"
+  organization: "cGMPdoc"
+  year: "2019"
+  summary: >-
+    Ciclo de vida de validación de sistemas computarizados (alineado
+    a GAMP 5).
+
+- name: "Formación de Auditores"
+  organization: "cGMPdoc"
+  year: "2019"
+  summary: >-
+    Formación de auditores para sistemas computarizados regulados
+    por GxP.
+
+# --- 2014 ---
+- name: "Master en Sistemas"
+  organization: "CentralTECH"
+  year: "2014"
+  summary: >-
+    Programa integral de sistemas cubriendo infraestructura, redes y
+    administración.
+
+# --- 2013 ---
+- name: "Microsoft Active Professional"
+  organization: "Microsoft"
+  year: "2013"
+  summary: >-
+    Reconocimiento de comunidad por la participación activa en
+    comunidades y eventos técnicos de Microsoft.
+
+# --- 2012 ---
+- name: "Programa de Liderazgo de Equipos de Trabajo"
+  organization: "IDEA ARG"
+  year: "2012"
+  summary: >-
+    Programa ejecutivo de liderazgo y gestión de equipos de trabajo.
+
+# --- 2011 ---
+- name: "Oracle 11g DBA"
+  organization: "CentralTECH"
+  year: "2011"
+  summary: >-
+    Capacitación en administración de bases de datos Oracle 11g.
+
+- name: "Enterprise Asterisk Administrator"
+  organization: "CentralTECH"
+  year: "2011"
+  summary: >-
+    Administración de sistemas de telefonía empresarial basados en
+    Asterisk.

--- a/_data/es/recognitions.yml
+++ b/_data/es/recognitions.yml
@@ -12,3 +12,10 @@
   summary: >
     Demostré comprensión de conceptos de seguridad, cumplimiento e
     identidad en los servicios en la nube de Microsoft.
+
+- award: "Microsoft Active Professional"
+  organization: Microsoft
+  year: "2013"
+  summary: >-
+    Reconocimiento de comunidad por la participación activa en
+    comunidades y eventos técnicos de Microsoft.

--- a/_data/es/strings.yml
+++ b/_data/es/strings.yml
@@ -8,6 +8,7 @@ not_looking: "No estoy buscando trabajo en este momento."
 # Section headers
 section_experience: "Experiencia Profesional"
 section_education: "Educación"
+section_continuing_education: "Formación Continua y Capacitación Especializada"
 section_projects: "Proyectos Destacados"
 section_skills: "Habilidades Técnicas"
 section_recognition: "Certificaciones y Reconocimientos"

--- a/_layouts/resume-i18n.html
+++ b/_layouts/resume-i18n.html
@@ -110,6 +110,29 @@
       {% endif %}
 
 
+      {% if site.resume_section_continuing_education %}
+      <!-- begin Continuing Education -->
+      <section class="content-section">
+
+        <header class="section-header">
+          <h2>{{ site.data[page.lang].strings.section_continuing_education }}</h2>
+        </header>
+
+        {% for course in site.data[page.lang].continuing_education %}
+        <div class="resume-item">
+          <h3 class="resume-item-title">{{ course.name }}</h3>
+          <h4 class="resume-item-details">{{ course.organization }} &bull; {{ course.year }}</h4>
+          {% if course.summary %}
+          <p class="resume-item-copy">{{ course.summary }}</p>
+          {% endif %}
+        </div><!-- end of resume-item -->
+        {% endfor %}
+
+      </section>
+      <!-- end Continuing Education -->
+      {% endif %}
+
+
       {% if site.resume_section_projects %}
       <!-- begin Projects -->
       <section class="content-section">


### PR DESCRIPTION
## Resumen

Refleja en el CV público el aprendizaje continuo del usuario — había 95 credenciales de LinkedIn ocultas (solo 2 certificaciones Microsoft + educación secundaria estaban visibles). La nueva sección curada expone los 16 cursos y certificaciones más relevantes manteniendo el CV compacto.

## Cambios

- **Nueva sección: "Continuing Education & Specialized Training"** renderizada entre Educación y Proyectos
  - 16 cursos curados de entre 95 credenciales de LinkedIn (badges de vendor, especialización pharma, programas de liderazgo)
  - Ordenado del más reciente al más antiguo (2023 → 2011)
  - Capacitación específica de pharma (cGMPdoc × 3, OQOTECH × 2, JENCK, SAFYBI) — antes invisible en el sitio
- **Sección de certificaciones**: se agregó **Microsoft Active Professional (2013)** — badge de comunidad que muestra 12+ años de participación en la comunidad Microsoft
- **Toque de layout**: nuevo bloque Liquid en `_layouts/resume-i18n.html` espejado con el patrón existente de Educación
- **Config**: nuevo flag `resume_section_continuing_education: true` + encabezados de sección EN/ES
- **EN/ES en lockstep** — mismas 16 entradas, mismos años, mismas organizaciones, descripciones en espejo

## Lo que NO se incluyó (y por qué)

- **UTN "Técnico Superior en Programación" (2018-2021)** — LinkedIn muestra el período como cerrado pero el usuario confirmó que no finalizó la carrera. No se muestra para no misrepresentar credenciales.
- **UNDAV "Ingeniería en Informática" (2015-2017)** — cancelada explícitamente por el usuario (según nota de LinkedIn), nunca mostrada.
- **AZ-900 (2021)** — el usuario optó por conservar solo DP-900 + SC-900 en la sección de reconocimientos.
- **Las otras 79 capacitaciones** (LinkedIn Learning, Platzi, cursos cortos de Coderhouse, etc.) — cubiertas por las 16 curadas; la lista completa sigue en LinkedIn.

## Verificación

- YAML válido (`yaml.safe_load`) en todos los archivos modificados/nuevos
- 16 entradas, orden descendente por fecha
- EN ↔ ES perfectamente paralelo (mismos nombres, años, organizaciones, conteo)
- Renderizado Liquid simulado produce una estructura HTML limpia
- La sección Educación no se toca
