### PR TITLE
Actualizar nombre de empresa y secciones de cursos

### DIFF
--- a/_data/en/experience.yml
+++ b/_data/en/experience.yml
@@ -1,5 +1,5 @@
 # Professional Experience
-- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+- company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
   position: "Head of Systems & Solutions Architect"
   duration: "February 2014 &mdash; Present"
   summary: >
@@ -15,7 +15,7 @@
     SCRUM, Kanban Boards, Lean, Pair Programming, and Roadmap Projection.
     Experience in roles such as Product Owner and Scrum Master.
 
-- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+- company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
   position: "Systems Supervisor"
   duration: "March 2009 &mdash; February 2014"
   summary: >
@@ -27,7 +27,7 @@
     suppliers. Foundation of DevOps practices and collaboration
     patterns later scaled into the Head of Systems role.
 
-- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+- company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
   position: "Maintenance Operator - Electromechanical Technician"
   duration: "January 2006 &mdash; March 2009"
   summary: >

--- a/_data/en/skills.yml
+++ b/_data/en/skills.yml
@@ -2,8 +2,8 @@
 - skill: Cloud Solutions (IaaS, PaaS, SaaS & IaC)
   description: Specialist in Microsoft Azure for designing and implementing scalable Cloud and hybrid infrastructure solutions.
 
-- skill: Software Development (.NET Core & Go)
-  description: Backend and application development using .NET Core and Go, including clean code practices and modern software engineering principles.
+- skill: Software Development (.NET Core)
+  description: Backend and application development using .NET Core, including clean code practices and modern software engineering principles.
 
 - skill: Databases (SQL Server & MariaDB/MySQL)
   description: Administration and development of relational databases with SQL Server and MariaDB/MySQL, including ORM with Entity Framework Core.

--- a/_data/en/strings.yml
+++ b/_data/en/strings.yml
@@ -1,14 +1,14 @@
 # UI strings in English
 site_title: "Christian Grimberg - Resume"
 job_title: "Head of Systems & Solutions Architect"
-executive_summary: "<p>Head of Systems and Solutions Architect with over 20 years of experience at Laboratorios NOVOCAP S.A. in the pharmaceutical industry. Focused on continuous improvement through the use of technology and on delivering solutions that maximize value for the organization. Specialized in Cloud and hybrid infrastructure, software development with .NET Core and Go, network and server administration, and agile project leadership.</p>"
+executive_summary: "<p>Head of Systems and Solutions Architect with over 20 years of experience at Laboratorios Novocap S.A. in the pharmaceutical industry. Focused on continuous improvement through the use of technology and on delivering solutions that maximize value for the organization. Specialized in Cloud and hybrid infrastructure, network and server administration, and agile project leadership.</p>"
 contact_button: "Contact me"
 not_looking: "I'm not looking for work right now."
 
 # Section headers
 section_experience: "Professional Experience"
 section_education: "Education"
-section_continuing_education: "Continuing Education & Specialized Training"
+section_continuing_education: "Courses"
 section_projects: "Featured Projects"
 section_skills: "Technical Skills"
 section_recognition: "Certifications & Recognition"

--- a/_data/es/experience.yml
+++ b/_data/es/experience.yml
@@ -1,5 +1,5 @@
 # Experiencia Profesional
-- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+- company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
   position: "Jefe de Sistemas & Arquitecto de Soluciones"
   duration: "Febrero 2014 &mdash; Presente"
   summary: >
@@ -19,7 +19,7 @@
     y Proyección de Roadmap. Experiencia en roles como Product Owner
     y Scrum Master.
 
-- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+- company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
   position: "Supervisor de Sistemas"
   duration: "Marzo 2009 &mdash; Febrero 2014"
   summary: >
@@ -33,7 +33,7 @@
     prácticas de DevOps y de los esquemas de colaboración que
     luego se consolidarían en el rol de Jefe de Sistemas.
 
-- company: "Laboratorios NOVOCAP S.A. (Buenos Aires, Argentina)"
+- company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
   position: "Operador de Mantenimiento - Técnico Electromecánico"
   duration: "Enero 2006 &mdash; Marzo 2009"
   summary: >

--- a/_data/es/skills.yml
+++ b/_data/es/skills.yml
@@ -4,9 +4,9 @@
     Especialista en Microsoft Azure para el diseño e implementación de
     soluciones de infraestructura Cloud e híbrida escalables.
 
-- skill: "Desarrollo de Software (.NET Core y Go)"
+- skill: "Desarrollo de Software (.NET Core)"
   description: >
-    Desarrollo backend y de aplicaciones utilizando .NET Core y Go,
+    Desarrollo backend y de aplicaciones utilizando .NET Core,
     incluyendo buenas prácticas de código limpio e ingeniería de
     software moderna.
 

--- a/_data/es/strings.yml
+++ b/_data/es/strings.yml
@@ -1,14 +1,14 @@
 # UI strings in Spanish
 site_title: "Christian Grimberg - Curriculum Vitae"
 job_title: "Jefe de Sistemas & Arquitecto de Soluciones"
-executive_summary: "<p>Jefe de Sistemas y Arquitecto de Soluciones con una trayectoria de más de 20 años en Laboratorios NOVOCAP S.A. dentro de la Industria Farmacéutica, enfocado en la mejora continua a través del uso de la tecnología y en brindar soluciones que maximicen el valor para la organización. Especializado en infraestructura Cloud e híbrida, desarrollo de software con .NET Core y Go, administración de redes y servidores, y liderazgo de proyectos bajo metodologías ágiles.</p>"
+executive_summary: "<p>Jefe de Sistemas y Arquitecto de Soluciones con una trayectoria de más de 20 años en Laboratorios Novocap S.A. dentro de la Industria Farmacéutica, enfocado en la mejora continua a través del uso de la tecnología y en brindar soluciones que maximicen el valor para la organización. Especializado en infraestructura Cloud e híbrida, administración de redes y servidores, y liderazgo de proyectos bajo metodologías ágiles.</p>"
 contact_button: "Contáctame"
 not_looking: "No estoy buscando trabajo en este momento."
 
 # Section headers
 section_experience: "Experiencia Profesional"
 section_education: "Educación"
-section_continuing_education: "Formación Continua y Capacitación Especializada"
+section_continuing_education: "Cursos"
 section_projects: "Proyectos Destacados"
 section_skills: "Habilidades Técnicas"
 section_recognition: "Certificaciones y Reconocimientos"

--- a/_layouts/resume-i18n.html
+++ b/_layouts/resume-i18n.html
@@ -110,8 +110,29 @@
       {% endif %}
 
 
+      {% if site.resume_section_recognition %}
+      <!-- begin Recognition -->
+      <section class="content-section">
+
+        <header class="section-header">
+          <h2>{{ site.data[page.lang].strings.section_recognition }}</h2>
+        </header>
+
+        {% for recognition in site.data[page.lang].recognitions %}
+        <div class="resume-item">
+          <h3 class="resume-item-title" itemprop="award">{{ recognition.award }}</h3>
+          <h4 class="resume-item-details">{{ recognition.organization }} &bull; {{ recognition.year }}</h4>
+          <p class="resume-item-copy">{{ recognition.summary }}</p>
+        </div>
+        {% endfor %}
+
+      </section>
+      <!-- end Recognition -->
+      {% endif %}
+
+
       {% if site.resume_section_continuing_education %}
-      <!-- begin Continuing Education -->
+      <!-- begin Courses -->
       <section class="content-section">
 
         <header class="section-header">
@@ -129,7 +150,7 @@
         {% endfor %}
 
       </section>
-      <!-- end Continuing Education -->
+      <!-- end Courses -->
       {% endif %}
 
 
@@ -169,26 +190,6 @@
 
       </section>
       <!-- end Skills -->
-      {% endif %}
-
-      {% if site.resume_section_recognition %}
-      <!-- begin Recognition -->
-      <section class="content-section">
-
-        <header class="section-header">
-          <h2>{{ site.data[page.lang].strings.section_recognition }}</h2>
-        </header>
-
-        {% for recognition in site.data[page.lang].recognitions %}
-        <div class="resume-item">
-          <h3 class="resume-item-title" itemprop="award">{{ recognition.award }}</h3>
-          <h4 class="resume-item-details">{{ recognition.organization }} &bull; {{ recognition.year }}</h4>
-          <p class="resume-item-copy">{{ recognition.summary }}</p>
-        </div>
-        {% endfor %}
-
-      </section>
-      <!-- end Recognition -->
       {% endif %}
 
       {% if site.resume_section_associations %}


### PR DESCRIPTION
## Resumen
- Actualiza “Laboratorios NOVOCAP S.A.” a “Laboratorios Novocap S.A.” en ambos idiomas.
- Elimina Go de la descripción/resumen y de Habilidades Técnicas, manteniéndolo en los cursos.
- Renombra la sección a “Cursos” / “Courses”.
- Mueve “Certificaciones y Reconocimientos” / “Certifications & Recognition” inmediatamente después de Educación / Education.

## Verificación
- YAML de `_data/en` y `_data/es`: PASS.
- Build Jekyll en Docker Ruby 3.2: PASS.
- HTML generado en inglés y español: nombre, títulos y orden de secciones verificados.
- `git diff --check`: PASS.

Nota: quedan fuera del commit los cambios locales preexistentes en `Gemfile.lock`, `.hermes/`, `.sass-cache/` y `_site/`.