### PR TITLE
Agregar 3 experiencias laborales previas (Válvulas Worcester, Cyber ZiOn, Reparaciones Banfield)

### DIFF
--- a/_data/en/experience.yml
+++ b/_data/en/experience.yml
@@ -35,8 +35,8 @@
     maintenance of industrial equipment. Supervision and coordination
     of technical suppliers.
 
-- company: "Válvulas Worcester (Buenos Aires, Argentina)"
-  position: "CNC Lathe/Machining Center Operator"
+- company: "Válvulas Worcester de Argentina (Capital Federal, Buenos Aires, Argentina)"
+  position: "CNC Machine Operator (Lathes and Machining Centers)"
   duration: "July 2005 &mdash; January 2006"
   summary: >
     Operation of computer numerically controlled (CNC) machines on

--- a/_data/en/experience.yml
+++ b/_data/en/experience.yml
@@ -34,3 +34,26 @@
     Electromechanical installations in technical areas. Coordinated
     maintenance of industrial equipment. Supervision and coordination
     of technical suppliers.
+
+- company: "Válvulas Worcester (Buenos Aires, Argentina)"
+  position: "CNC Lathe/Machining Center Operator"
+  duration: "July 2005 &mdash; January 2006"
+  summary: >
+    Operation of computer numerically controlled (CNC) machines on
+    lathes and machining centers. Machining of parts for oilfield
+    valves. Maintenance and tuning of CNC programs.
+
+- company: "Cyber ZiOn (Banfield, Buenos Aires, Argentina)"
+  position: "PC Assembly & Repair Technician"
+  duration: "October 2003 &mdash; January 2006"
+  summary: >
+    Assembly and repair of in-store PCs. Technical advisory for
+    customers. Maintenance of the cybercafé system and the network
+    of 10 workstations.
+
+- company: "Reparaciones Banfield S.R.L. (Banfield, Buenos Aires, Argentina)"
+  position: "Home Appliance Repair Technician"
+  duration: "October 2002 &mdash; June 2005"
+  summary: >
+    Repair of all types of home appliances. Customer service and
+    advisory.

--- a/_data/es/experience.yml
+++ b/_data/es/experience.yml
@@ -41,8 +41,8 @@
     coordinado de equipamiento industrial. Atención y supervisión de
     proveedores técnicos.
 
-- company: "Válvulas Worcester (Buenos Aires, Argentina)"
-  position: "Operador de Máquinas Tornos/Centros CNC"
+- company: "Válvulas Worcester de Argentina (Capital Federal, Buenos Aires, Argentina)"
+  position: "Operador de Máquinas CNC (Tornos y Centros)"
   duration: "Julio 2005 &mdash; Enero 2006"
   summary: >
     Operación de máquinas de mecanizado por control numérico (CNC)

--- a/_data/es/experience.yml
+++ b/_data/es/experience.yml
@@ -40,3 +40,27 @@
     Instalaciones electromecánicas en áreas técnicas. Mantenimiento
     coordinado de equipamiento industrial. Atención y supervisión de
     proveedores técnicos.
+
+- company: "Válvulas Worcester (Buenos Aires, Argentina)"
+  position: "Operador de Máquinas Tornos/Centros CNC"
+  duration: "Julio 2005 &mdash; Enero 2006"
+  summary: >
+    Operación de máquinas de mecanizado por control numérico (CNC)
+    en tornos y centros de mecanizado. Mecanizado de piezas para
+    válvulas petrolíferas. Mantenimiento y ajuste de programas
+    CNC.
+
+- company: "Cyber ZiOn (Banfield, Buenos Aires, Argentina)"
+  position: "Técnico en armado y reparación de PC"
+  duration: "Octubre 2003 &mdash; Enero 2006"
+  summary: >
+    Armado y reparación de PCs del local. Asesoramiento técnico a
+    clientes. Mantenimiento del sistema del ciber y de la red
+    informática de los 10 puestos.
+
+- company: "Reparaciones Banfield S.R.L. (Banfield, Buenos Aires, Argentina)"
+  position: "Técnico en Reparación de Electrodomésticos"
+  duration: "Octubre 2002 &mdash; Junio 2005"
+  summary: >
+    Reparación de todo tipo de electrodomésticos. Atención y
+    asesoramiento a clientes.


### PR DESCRIPTION
## Resumen
- Agrega tres experiencias laborales previas a la carrera en IT, en orden cronológico newest-first por fecha de inicio, en ambos idiomas (EN/ES en lockstep).
  - **Válvulas Worcester** (Buenos Aires) — *Operador de Máquinas Tornos/Centros CNC* — Jul 2005 → Ene 2006.
  - **Cyber ZiOn** (Banfield, Buenos Aires) — *Técnico en armado y reparación de PC* — Oct 2003 → Ene 2006.
  - **Reparaciones Banfield S.R.L.** (Banfield, Buenos Aires) — *Técnico en Reparación de Electrodomésticos* — Oct 2002 → Jun 2005.

## Verificación
- YAML de `_data/en` y `_data/es`: PASS (parseables, todos los campos requeridos presentes, orden newest-first por fecha de inicio).
- Build Jekyll en Docker Ruby 3.2: PASS (`bundle exec jekyll build --baseurl ""`).
- HTML generado en EN y ES: las 6 entradas aparecen en el orden correcto (verificado con `grep -n` sobre `<h4 class="resume-item-details">` dentro de `<!-- begin Experience -->`).
- `git diff --check`: PASS.
- Paridad EN↔ES: 6 entradas en cada archivo, mismos meses de inicio.

## Notas
- **Sobre los gaps en el verificador estructural**: Cyber ZiOn (Oct 2003 → Ene 2006) y Válvulas Worcester (Jul 2005 → Ene 2006) se solapan en el tiempo, y Cyber ZiOn también se solapa parcialmente con Reparaciones Banfield (Oct 2002 → Jun 2005). El script de verificación reporta estos como gaps, pero reflejan concurrencia real de los roles (Cyber ZiOn era trabajo adicional en paralelo), no huecos ocultos en la línea temporal. Se deja como está porque mover fechas para encadenar falsearía la historia.
- **Sobre las referencias de las experiencias**: no se incluyen nombres de dueños/jefes (p. ej. `Batty Zamolski` de Cyber ZiOn no se agregaron), siguiendo la decisión de no incluir referencias de ese tipo en la sección.
- Fuera del commit: `Gemfile.lock` (modificado localmente por `bundle install` en Docker), `.hermes/`, `.sass-cache/`, `_site/`.