### PR TITLE
Reemplazar proyectos placeholder por 37 proyectos reales (2009-2026)

### DIFF
--- a/_data/en/projects.yml
+++ b/_data/en/projects.yml
@@ -1,16 +1,185 @@
 # Featured Projects
-- project: AI Agent Context System
-  role: Creator & Maintainer
+- project: "Microsoft Fabric deployment integrated with SAP S/4HANA"
+  role: Technical Lead
+  duration: 2026 &mdash; Present
+  description: Deployed Microsoft Fabric connected to the SAP S/4HANA AEP environment and to other plant systems to centralize the organization's data analytics and reporting in a single unified platform.
+
+- project: "Second phase of Microsoft Copilot rollout"
+  role: Technical Lead
+  duration: 2026 &mdash; Present
+  description: Continued the Microsoft 365 Copilot rollout started in 2025, expanding coverage to new roles and use cases across the organization.
+
+- project: "Microsoft 365 Copilot and Copilot Studio implementation"
+  role: Technical Lead
+  duration: 2025 &mdash; Present
+  description: Implemented Microsoft 365 Copilot and custom agents with Copilot Studio for different roles in the organization, automating workflows and boosting productivity with generative AI integrated into the Microsoft 365 ecosystem.
+
+- project: "EDR deployment with Microsoft Defender for Cloud"
+  role: Security Administrator
+  duration: 2025 &mdash; Present
+  description: Deployed Microsoft Defender for Cloud as the EDR solution for endpoint and cloud workload protection, integrating detection, response, and security recommendations across the organization's infrastructure.
+
+- project: "CMDB implementation in Jira Service Management"
+  role: ITSM Administrator
+  duration: 2025 &mdash; Present
+  description: Implemented the Configuration Management Database (CMDB) inside Jira Service Management to centralize IT asset management, including relationships and lifecycle, providing full visibility of the technology inventory across the organization.
+
+- project: "Atlassian Jira Software and Jira Service Management rollout"
+  role: Tools Administrator
   duration: 2024 &mdash; Present
-  url: "https://github.com/ChristianGrimberg/ChristianGrimberg"
-  description: Developed AGENTS.md - a comprehensive context system for AI agents that defines coding standards, technology preferences, and architectural choices. This innovative approach enables AI assistants to provide more contextual and aligned assistance in software projects.
+  description: Implemented and rolled out Atlassian Jira Software for agile project management and Jira Service Management as the corporate help desk, unifying work management and IT services in a single platform.
 
-- project: Enterprise .NET Solutions
-  role: Lead Architect & Developer
-  duration: 2018 &mdash; Present
-  description: Architected and developed multiple enterprise-grade applications using .NET, implementing Clean Architecture and DDD patterns. Built scalable microservices with Azure cloud infrastructure, automated CI/CD pipelines, and integrated AI capabilities for business process optimization.
+- project: "Azure Recovery Services integration for the backup system"
+  role: Infrastructure Engineer
+  duration: 2023 &mdash; Present
+  description: Integrated Azure Recovery Services with the backup system to store a second off-site copy across different Vaults, strengthening the business continuity and disaster recovery strategy for both on-premises and Azure environments.
 
-- project: DevOps Automation Framework
-  role: Creator
+- project: "DevOps backup and data retention system"
+  role: Developer, Scrum Master, and Product Owner
+  duration: 2022 &mdash; Present
+  description: Designed and built a backup and data retention system for files and SQL Server databases, based on PowerShell and .NET Core modules, integrated with Azure DevOps and GitHub for CI/CD, version control, and collaboration; led the Scrum cycle with two-week sprints, alternating between Scrum Master and Product Owner.
+
+- project: "Microsoft Intune implementation for MDM and MAM"
+  role: Device Administrator
+  duration: 2021 &mdash; Present
+  description: Implemented Microsoft Intune for unified Mobile Device Management (MDM) and Mobile Application Management (MAM) across the organization, deploying security baselines, compliance policies, and corporate data protection on Windows, iOS, and Android endpoints.
+
+- project: "Legacy applications migration to Azure IaaS"
+  role: Cloud Infrastructure Engineer
   duration: 2020 &mdash; Present
-  description: Created comprehensive PowerShell and Bash automation frameworks for infrastructure provisioning, deployment automation, and system monitoring. Significantly reduced deployment times and improved system reliability through Infrastructure as Code practices.
+  description: Led the migration of the Sifra Suite and ADP Payroll applications to Microsoft Azure IaaS virtual machines, connecting the cloud environments to on-premises sites through site-to-site VPN tunnels against the Fortinet routers at each location.
+
+- project: "Remote application access with RDS and Azure VPN"
+  role: Infrastructure Engineer
+  duration: 2020 &mdash; Present
+  description: Implemented Remote Desktop Services roles with RemoteApp to publish the Sifra Suite and ADP Payroll clients to end users, and deployed the Azure VPN client for remote connections in the context of the COVID-19 quarantine in Argentina.
+
+- project: "GAMP 5 adoption for computerized system validation"
+  role: Validation Lead
+  duration: 2019 &mdash; Present
+  description: Led the documentation of the IT department's processes under the GAMP 5 guidelines, establishing the computerized system validation framework required by the regulated pharmaceutical industry, including functional and design specifications plus installation, operational, and performance qualification (IQ/OQ/PQ) of critical systems.
+
+- project: "Microsoft Teams rollout in the organization"
+  role: Collaboration Administrator
+  duration: 2019 &mdash; Present
+  description: Deployed Microsoft Teams as the corporate collaboration and communication platform, integrating chat, meetings, calling, and file sharing within the organization's Office 365 ecosystem.
+
+- project: "First data center in Microsoft Azure"
+  role: Cloud Infrastructure Engineer
+  duration: 2019 &mdash; Present
+  description: Designed and built the first data center in Microsoft Azure as the primary DC for the organization on Windows Server 2019, laying the foundation of the hybrid cloud strategy and remote operations procedures.
+
+- project: "Door interlocking system with Arduino UNO"
+  role: Hardware and Firmware Developer
+  duration: 2018 &mdash; Present
+  description: Designed and implemented an electronic door interlocking system for the organization's plants based on Arduino UNO boards, supporting multiple interlocking modes and integrated with the time clocks to centrally manage physical access control.
+
+- project: "Digital Payroll Book system for AFIP"
+  role: .NET Developer
+  duration: 2017 &mdash; Present
+  description: Designed and built a client-server Digital Payroll Book application for AFIP in .NET Framework with C#, structured in layers (UI, business logic, ORM, and SQL Server) and integrated with ADP Payroll for payroll runs and with the Absence Control module for inputs; the organization was one of 10 companies selected in Argentina to submit the payroll book 100% digitally.
+
+- project: "Siemens digital telephony to Asterisk VoIP migration"
+  role: Telecommunications Administrator
+  duration: 2016 &mdash; Present
+  description: Led the migration from the Siemens digital telephony platform to VoIP PBXs based on Asterisk, acquiring new IP phones and interconnecting every site of the organization through the existing Fortinet VPN tunnels.
+
+- project: "Watchguard retirement and perimeter consolidation on Fortinet"
+  role: Network and Security Engineer
+  duration: 2016 &mdash; Present
+  description: Executed the end-of-life plan for the Watchguard devices and consolidated perimeter security and inter-site routing on Fortinet firewalls and routers, standardizing the network security vendor across the entire organization.
+
+- project: "Upgrade to Windows Server 2012 R2"
+  role: Server Administrator
+  duration: 2016 &mdash; Present
+  description: Executed the server upgrade plan to Windows Server 2012 R2, migrating roles, services, and policies from Windows Server 2008 R2 without impacting the organization's daily operations.
+
+- project: "SAP S/4HANA implementation"
+  role: Project Leader
+  duration: 2015 &mdash; 2016
+  description: Led as Project Leader the implementation of the SAP S/4HANA ERP, including the rollout of standard modules, the balance migration from the previous ERP, integrated testing, and the productive go-live on January 1, 2016.
+
+- project: "SAP S/4HANA and Sifra Suite integration"
+  role: Interface Developer
+  duration: 2015 &mdash; 2016
+  description: Designed and implemented the integration interface between SAP S/4HANA and the Sifra Suite weighing-center system to make the ERP cutover transparent, ensuring the exchange of production orders, batches, materials, fractionations, and assemblies between both systems.
+
+- project: "Ezeiza plant data center with Fortinet and Cisco"
+  role: Network and Infrastructure Engineer
+  duration: 2015 &mdash; Present
+  description: Designed and built a new data center at the Ezeiza plant, including Fortinet firewalls and routers and Cisco switches, replicating the high-availability architecture of the other sites and adding a new location to the corporate network.
+
+- project: "Migration to 100% digital telephony with Siemens PBX"
+  role: Telecommunications Administrator
+  duration: 2014 &mdash; Present
+  description: Completed the migration from analog to 100% digital telephony on the Siemens PBX, modernizing the organization's internal phone plant and unifying the dial plan across digital and analog extensions.
+
+- project: "Network infrastructure and VPNs with Watchguard and Fortinet"
+  role: Network and Security Engineer
+  duration: 2014 &mdash; Present
+  description: Deployed new data centers at the commercial locations and extended the Avellaneda plant data center, interconnecting all sites through VPN tunnels between Watchguard and Fortinet devices in a unified corporate WAN.
+
+- project: "ADP Payroll and HR modules implementation"
+  role: Project Leader and Developer
+  duration: 2014 &mdash; Present
+  description: Led the migration of the payroll system to ADP Payroll, adding the Absence Control, Personnel Selection, and Employee Management modules, and developed the SQL Server interface that feeds clock-in data from the time clocks into the absence control module.
+
+- project: "Completion of the Office 365 migration"
+  role: Infrastructure Administrator
+  duration: 2012 &mdash; 2013
+  description: Completed the migration to the Office 365 cloud platform started in 2012, finalizing the transition of the File Server to SharePoint, of email to Exchange Online, and of the internal web sites to Windows Azure during the second half of 2013.
+
+- project: "Remote ERP access via Terminal Server"
+  role: Server Administrator
+  duration: 2013 &mdash; Present
+  description: Implemented Terminal Server to enable remote ERP access from outside the corporate network, allowing authorized users to operate the system securely from any location.
+
+- project: "ERP process automation on SQL Server"
+  role: SQL DBA and Developer
+  duration: 2012 &mdash; Present
+  description: Designed and implemented stored procedures, triggers, user-defined types, and views on SQL Server to automate core processes of the Stradivarius G3 ERP, including stock reconciliation, accounting books, and regulatory reports to Sedronar and for Psychotropic substances.
+
+- project: "Email and collaboration migration to Office 365"
+  role: Infrastructure Administrator
+  duration: 2012 &mdash; 2013
+  description: Executed the migration of the File Server to SharePoint and of Exchange Server 2010 to Exchange Online as part of the Office 365 adoption, modernizing the corporate collaboration and email platform.
+
+- project: "IIS web sites migration to Windows Azure"
+  role: Web Administrator
+  duration: 2012 &mdash; Present
+  description: Migrated the internal IIS web sites to Windows Azure, taking the organization's first step toward cloud infrastructure and freeing capacity from the on-premises data center.
+
+- project: "Sifra Suite implementation and ERP integration"
+  role: Project Leader and Developer
+  duration: 2011 &mdash; Present
+  description: Led the implementation of the Sifra Suite client-server weighing-center system for the pharmaceutical industry on Windows with SQL Server from the organization's side, and designed and built the database interface to exchange production orders, batches, materials, fractionations, and assemblies between the ERP and Sifra.
+
+- project: "Centralized printing service with Ricoh Argentina"
+  role: Print Services Administrator
+  duration: 2010 &mdash; Present
+  description: Implemented a corporate centralized printing service contracted with Ricoh Argentina, including print accounting, differentiated black-and-white and color quotas, and periodic reporting to management on consumption and costs.
+
+- project: "Reporting and database administration for Stradivarius G3 ERP"
+  role: SQL DBA and Report Developer
+  duration: 2010 &mdash; Present
+  description: Designed and built new reports for the Stradivarius G3 ERP with Crystal Reports in coordination with the Finnegans vendor, and trained as a SQL Server database administrator to handle deployment, maintenance, and tuning of the organization's databases.
+
+- project: "IT department creation and Windows server administration"
+  role: Infrastructure Lead
+  duration: 2009 &mdash; Present
+  description: Built the IT department from scratch and took ownership of the Windows server administration, including the domain migration from Windows Server 2003 to Windows Server 2008 / 2008 R2 and the Exchange Server 2003 to 2007 migration.
+
+- project: "Network infrastructure and perimeter security with Watchguard"
+  role: Network Engineer
+  duration: 2009 &mdash; Present
+  description: Administered the network infrastructure and perimeter security based on Watchguard firewalls and routers, specializing in policy configuration, VLAN segmentation, and VPN tunnel management alongside Cisco CCNA training.
+
+- project: "Tier-1 support for the Stradivarius G3 ERP"
+  role: ERP Support Analyst
+  duration: 2009 &mdash; Present
+  description: Provided tier-1 support for the Stradivarius G3 ERP in direct contact with the Finnegans vendor, managing incidents, requests, and configurations of the organization's core system.
+
+- project: "IT team leadership"
+  role: IT Lead
+  duration: 2009 &mdash; Present
+  description: Led the initial shaping of the IT team, starting with one Systems Analyst reporting to me, and consolidated the department's internal operations with a focus on support, infrastructure, and continuous improvement projects.

--- a/_data/es/projects.yml
+++ b/_data/es/projects.yml
@@ -1,16 +1,185 @@
 # Proyectos Destacados
-- project: Sistema de Contexto para Agentes de IA
-  role: Creador y Mantenedor
+- project: "Despliegue de Microsoft Fabric integrado a SAP S/4HANA"
+  role: Líder Técnico
+  duration: 2026 &mdash; Presente
+  description: Desplegué Microsoft Fabric conectado al entorno AEP de SAP S/4HANA y a otros sistemas de planta para consolidar el análisis de datos de la organización en una plataforma unificada de analítica y reporting.
+
+- project: "Segunda fase de Microsoft Copilot en la organización"
+  role: Líder Técnico
+  duration: 2026 &mdash; Presente
+  description: Continué el despliegue de Microsoft 365 Copilot iniciado en 2025, ampliando la cobertura a nuevos roles y casos de uso dentro de la organización.
+
+- project: "Implementación de Microsoft 365 Copilot y Copilot Studio"
+  role: Líder Técnico
+  duration: 2025 &mdash; Presente
+  description: Implementé Microsoft 365 Copilot y agentes personalizados con Copilot Studio para diferentes roles de la organización, automatizando flujos de trabajo y mejorando la productividad con IA generativa integrada en el ecosistema Microsoft 365.
+
+- project: "Despliegue de EDR con Microsoft Defender for Cloud"
+  role: Administrador de Seguridad
+  duration: 2025 &mdash; Presente
+  description: Desplegué Microsoft Defender for Cloud como solución EDR para protección de endpoints y cargas de trabajo en la nube, integrando detección, respuesta y recomendaciones de seguridad en la infraestructura de la organización.
+
+- project: "Implementación de CMDB en Jira Service Management"
+  role: Administrador de ITSM
+  duration: 2025 &mdash; Presente
+  description: Implementé la CMDB (Configuration Management Database) dentro de Jira Service Management para la gestión centralizada de activos de TI, sus relaciones y su ciclo de vida, dando visibilidad completa del inventario tecnológico a la organización.
+
+- project: "Despliegue de Atlassian Jira Software y Jira Service Management"
+  role: Administrador de Herramientas
   duration: 2024 &mdash; Presente
-  url: "https://github.com/ChristianGrimberg/ChristianGrimberg"
-  description: Desarrollé AGENTS.md - un sistema de contexto integral para agentes de IA que define estándares de código, preferencias tecnológicas y opciones arquitectónicas. Este enfoque innovador permite a los asistentes de IA proporcionar asistencia más contextual y alineada en proyectos de software.
+  description: Implementé y desplegué Atlassian Jira Software para la gestión de proyectos ágiles y Jira Service Management como mesa de ayuda corporativa, unificando la gestión del trabajo y los servicios de TI en una sola plataforma.
 
-- project: Soluciones Empresariales .NET
-  role: Arquitecto Principal y Desarrollador
-  duration: 2018 &mdash; Presente
-  description: Arquitecturé y desarrollé múltiples aplicaciones de nivel empresarial usando .NET, implementando patrones de Arquitectura Limpia y DDD. Construí microservicios escalables con infraestructura en la nube de Azure, pipelines CI/CD automatizados e integré capacidades de IA para optimización de procesos de negocio.
+- project: "Integración de Azure Recovery Services al sistema de respaldos"
+  role: Ingeniero de Infraestructura
+  duration: 2023 &mdash; Presente
+  description: Integré Azure Recovery Services al sistema de respaldos para alojar una segunda copia off-site en diferentes Vaults异地, fortaleciendo la estrategia de continuidad de negocio y recuperación ante desastres del entorno on-premises y Azure.
 
-- project: Framework de Automatización DevOps
-  role: Creador
+- project: "Sistema DevOps de respaldo y retención de datos"
+  role: Desarrollador, Scrum Master y Product Owner
+  duration: 2022 &mdash; Presente
+  description: Diseñé e implementé un sistema de respaldo y retención de datos para archivos y bases de datos SQL Server, basado en módulos de PowerShell y .NET Core, integrado con Azure DevOps y GitHub para CI/CD, versionado y colaboración; lideré el ciclo Scrum con sprints de dos semanas alternando entre Scrum Master y Product Owner.
+
+- project: "Implementación de Microsoft Intune para MDM y MAM"
+  role: Administrador de Dispositivos
+  duration: 2021 &mdash; Presente
+  description: Implementé Microsoft Intune para la administración unificada de dispositivos móviles (MDM) y aplicaciones móviles (MAM) en la organización, desplegando baselines de seguridad, políticas de cumplimiento y protección de datos corporativos en endpoints Windows, iOS y Android.
+
+- project: "Migración de aplicaciones legadas a Azure IaaS"
+  role: Ingeniero de Infraestructura Cloud
   duration: 2020 &mdash; Presente
-  description: Creé frameworks integrales de automatización en PowerShell y Bash para aprovisionamiento de infraestructura, automatización de despliegues y monitoreo de sistemas. Reduje significativamente los tiempos de despliegue y mejoré la confiabilidad del sistema mediante prácticas de Infraestructura como Código.
+  description: Lideré la migración de las aplicaciones de Sifra Suite y ADP Payroll a máquinas virtuales en Microsoft Azure IaaS, conectando los entornos a las locaciones on-premises mediante túneles VPN site-to-site contra los routers Fortinet de cada sucursal.
+
+- project: "Acceso remoto a aplicaciones mediante RDS y Azure VPN"
+  role: Ingeniero de Infraestructura
+  duration: 2020 &mdash; Presente
+  description: Implementé los roles de Remote Desktop Services con RemoteApp para publicar los clientes de Sifra Suite y ADP Payroll hacia los usuarios, y desplegué el cliente VPN de Azure para las conexiones remotas en el contexto de cuarentena por COVID-19 en Argentina.
+
+- project: "Adopción de GAMP 5 para validación de sistemas computerizados"
+  role: Líder de Validaciones
+  duration: 2019 &mdash; Presente
+  description: Lideré la documentación de los procesos del área de Sistemas bajo las guías GAMP 5, estableciendo el marco de validación de sistemas computerizados requerido por la industria farmacéutica regulada, incluyendo especificaciones funcionales, de diseño, instalación, operación y性能 (IQ/OQ/PQ) de los sistemas críticos.
+
+- project: "Implementación de Microsoft Teams en la organización"
+  role: Administrador de Colaboración
+  duration: 2019 &mdash; Presente
+  description: Desplegué Microsoft Teams como plataforma de colaboración y comunicación corporativa, integrando chat, reuniones, llamadas y compartición de archivos en el ecosistema de Office 365 de la organización.
+
+- project: "Primer centro de datos en Microsoft Azure"
+  role: Ingeniero de Infraestructura Cloud
+  duration: 2019 &mdash; Presente
+  description: Diseñé e implementé el primer centro de datos en Microsoft Azure como DC primario para la organización, sobre Windows Server 2019, estableciendo las bases de la estrategia cloud híbrida y los procedimientos de operación remota.
+
+- project: "Sistema de enclavamiento de puertas con Arduino UNO"
+  role: Desarrollador de Hardware y Firmware
+  duration: 2018 &mdash; Presente
+  description: Diseñé e implementé un sistema de enclavamiento electrónico de puertas para las plantas de la organización basado en placas Arduino UNO, soportando múltiples modos de enclavamiento e integrado a los relojes de fichada para administrar los controles de acceso físico de manera centralizada.
+
+- project: "Sistema de Libro de Sueldos Digital para AFIP"
+  role: Desarrollador .NET
+  duration: 2017 &mdash; Presente
+  description: Diseñé e implementé en .NET Framework con C# una aplicación cliente-servidor de Libro de Sueldos Digital para AFIP, desarrollada en capas (UI, lógica de negocio, ORM y SQL Server) e integrada con ADP Payroll para liquidaciones de sueldos y con el módulo de Control de Ausentismo para novedades, siendo la organización una de las 10 empresas seleccionadas en Argentina para enviar el libro de sueldos 100% digital.
+
+- project: "Migración de telefonía digital Siemens a VoIP con Asterisk"
+  role: Administrador de Telecomunicaciones
+  duration: 2016 &mdash; Presente
+  description: Lideré la migración de la telefonía digital de la central Siemens hacia centrales VoIP basadas en Asterisk, adquiriendo nuevos teléfonos IP e interconectando todas las locaciones de la organización a través de los túneles VPN sobre Fortinet.
+
+- project: "Retiro de Watchguard y consolidación de perimetral en Fortinet"
+  role: Ingeniero de Redes y Seguridad
+  duration: 2016 &mdash; Presente
+  description: Ejecuté el plan de fin de ciclo de vida de los dispositivos Watchguard y consolidé la seguridad perimetral y el ruteo inter-sucursales en firewalls y routers Fortinet, estandarizando el vendor de seguridad de red en toda la organización.
+
+- project: "Actualización a Windows Server 2012 R2"
+  role: Administrador de Servidores
+  duration: 2016 &mdash; Presente
+  description: Ejecuté el plan de actualización de los servidores a Windows Server 2012 R2, migrando roles, servicios y políticas desde Windows Server 2008 R2 sin afectar la operación de la organización.
+
+- project: "Implementación de SAP S/4HANA"
+  role: Líder de Proyecto
+  duration: 2015 &mdash; 2016
+  description: Lideré como Project Leader la implementación del ERP SAP S/4HANA, incluyendo el despliegue de módulos estándar, la migración de saldos desde el ERP anterior, el testing integrado y el go-live productivo el 1 de enero de 2016.
+
+- project: "Integración SAP S/4HANA con Sifra Suite"
+  role: Desarrollador de Interfaces
+  duration: 2015 &mdash; 2016
+  description: Diseñé e implementé la interfaz de integración entre SAP S/4HANA y el sistema de central de pesadas Sifra Suite para que la transición al nuevo ERP fuera transparente, asegurando el intercambio de órdenes de producción, lotes, materiales, fraccionamientos y ensambles entre ambos sistemas.
+
+- project: "Centro de datos en planta Ezeiza con Fortinet y Cisco"
+  role: Ingeniero de Redes e Infraestructura
+  duration: 2015 &mdash; Presente
+  description: Diseñé y levanté un nuevo centro de datos en la planta Ezeiza, incluyendo firewall y routers Fortinet y switches Cisco, replicando la arquitectura de alta disponibilidad de los demás sitios y sumando una locación más a la red corporativa.
+
+- project: "Migración a 100% telefonía digital con central Siemens"
+  role: Administrador de Telecomunicaciones
+  duration: 2014 &mdash; Presente
+  description: Completé la migración de la telefonía analógica a telefonía 100% digital sobre la central Siemens, modernizando la planta interna de la organización y unificando la numeración entre internos digitales y analógicos.
+
+- project: "Infraestructura de red y VPNs con Watchguard y Fortinet"
+  role: Ingeniero de Redes y Seguridad
+  duration: 2014 &mdash; Presente
+  description: Desplegué nuevos centros de datos en las ubicaciones comerciales y extendí el centro de datos de la planta Avellaneda, interconectando las locaciones mediante túneles VPN entre dispositivos Watchguard y Fortinet en una WAN corporativa unificada.
+
+- project: "Implementación de ADP Payroll y módulos de RR. HH."
+  role: Líder de Proyecto y Desarrollador
+  duration: 2014 &mdash; Presente
+  description: Lideré la migración del sistema de liquidación de sueldos a ADP Payroll, incorporando los módulos de Control de Ausentismo, Selección de Personal y Gestión del Empleado, y desarrollé en SQL Server la interfaz de toma de fichadas desde los relojes hacia el módulo de control de ausentismo.
+
+- project: "Cierre de la migración a Office 365"
+  role: Administrador de Infraestructura
+  duration: 2012 &mdash; 2013
+  description: Completé la migración a la plataforma cloud de Office 365 iniciada en 2012, finalizando la transición del File Server a SharePoint, del correo electrónico a Exchange Online y de los sitios web internos a Windows Azure durante el segundo semestre de 2013.
+
+- project: "Acceso remoto al ERP mediante Terminal Server"
+  role: Administrador de Servidores
+  duration: 2013 &mdash; Presente
+  description: Implementé Terminal Server para habilitar la conexión remota al ERP desde el exterior, permitiendo a usuarios autorizados operar el sistema desde fuera de la red corporativa de manera segura.
+
+- project: "Automatización de procesos del ERP en SQL Server"
+  role: DBA y Desarrollador SQL
+  duration: 2012 &mdash; Presente
+  description: Diseñé e implementé stored procedures (USP), triggers, tipos definidos por el usuario (UDT) y views en SQL Server para automatizar procesos internos del ERP Stradivarius G3, incluyendo conciliación de stocks, libros contables y reportes regulatorios a Sedronar y de Psicotrópicos.
+
+- project: "Migración de correo y colaboración a Office 365"
+  role: Administrador de Infraestructura
+  duration: 2012 &mdash; 2013
+  description: Ejecuté la migración del File Server a SharePoint y de Exchange Server 2010 a Exchange Online en el marco de la adopción de Office 365, modernizando la plataforma de colaboración y correo corporativo.
+
+- project: "Migración de sitios web IIS a Windows Azure"
+  role: Administrador Web
+  duration: 2012 &mdash; Presente
+  description: Migré los sitios web internos sobre IIS a Windows Azure, dando el primer paso de la organización hacia infraestructura cloud y liberando capacidad del centro de datos on-premises.
+
+- project: "Implementación de Sifra Suite e integración con el ERP"
+  role: Líder de Proyecto y Desarrollador
+  duration: 2011 &mdash; Presente
+  description: Lideré por parte de la organización la implementación del sistema cliente-servidor Sifra Suite para central de pesadas en entorno Windows con SQL Server, y diseñé e implementé la interfaz en base de datos para el intercambio de órdenes de producción, lotes, materiales, fraccionamientos y ensambles entre el ERP y Sifra.
+
+- project: "Servicio centralizado de impresión con Ricoh Argentina"
+  role: Administrador de Servicios de Impresión
+  duration: 2010 &mdash; Presente
+  description: Implementé un servicio corporativo de impresión centralizado contratado a Ricoh Argentina, incluyendo contabilidad de impresiones, cuotas diferenciadas de blanco y negro y color, y reporting periódico a la dirección sobre consumo y costos.
+
+- project: "Reportes y administración de BD del ERP Stradivarius G3"
+  role: DBA y Desarrollador de Reportes
+  duration: 2010 &mdash; Presente
+  description: Diseñé e implementé nuevos reportes e informes para el ERP Stradivarius G3 con Crystal Reports en coordinación con el fabricante Finnegans, y me formé como administrador de bases de datos SQL Server para gestionar el despliegue, mantenimiento y tuning de las bases de la organización.
+
+- project: "Creación del área de Sistemas y administración de servidores Windows"
+  role: Responsable de Infraestructura
+  duration: 2009 &mdash; Presente
+  description: Creé desde cero el área de Sistemas en la organización, siendo responsable de la administración de los servidores Windows, incluyendo la migración del dominio desde Windows Server 2003 a Windows Server 2008 / 2008 R2 y la migración de Exchange Server 2003 a Exchange 2007.
+
+- project: "Infraestructura de red y seguridad perimetral con Watchguard"
+  role: Ingeniero de Redes
+  duration: 2009 &mdash; Presente
+  description: Administré la infraestructura de redes y la seguridad perimetral basada en firewalls y routers Watchguard, especializándome en la configuración de políticas, segmentación por VLANs y administración de túneles VPN durante la formación en CCNA de Cisco.
+
+- project: "Soporte de primer nivel del ERP Stradivarius G3"
+  role: Analista de Soporte ERP
+  duration: 2009 &mdash; Presente
+  description: Brindé soporte de primer nivel del ERP Stradivarius G3 en contacto directo con el fabricante Finnegans, gestionando incidentes, requerimientos y configuraciones del sistema core de la organización.
+
+- project: "Liderazgo del equipo de Sistemas"
+  role: Líder de Sistemas
+  duration: 2009 &mdash; Presente
+  description: Lideré la conformación inicial del equipo de Sistemas, comenzando con un Analista de Sistemas a mi cargo, y consolidé la operación interna del área con foco en soporte, infraestructura y proyectos de mejora continua.


### PR DESCRIPTION
## Resumen

Reemplaza las 3 entradas placeholder de la sección 'Proyectos Destacados' / 'Featured Projects' ("AI Agent Context System", "Enterprise .NET Solutions", "DevOps Automation Framework") por los **37 proyectos reales** llevados adelante en la organización desde 2009 hasta la fecha, ordenados del más reciente al más antiguo y espejados 1:1 entre ES y EN.

## Cambios

- `_data/es/projects.yml`: 37 entradas, todas redactadas en pretérito y con stack técnico en el cuerpo de la descripción para ATS.
- `_data/en/projects.yml`: 37 entradas equivalentes, con títulos y duraciones espejadas (no traducción literal; cada idioma usa el orden de palabras más natural).

## Stack cubierto (entre los 37)

Windows Server 2003/2008 R2/2012 R2/2019, Active Directory, Exchange Server 2003/2007/2010/Online, Watchguard Firebox, Fortinet, Cisco (CCNA), switches Cisco, VLANs, VPN site-to-site, Asterisk VoIP, SAP S/4HANA (AEP), Sifra Suite, ADP Payroll, SQL Server (DBA + USP/triggers/UDTs/views), Crystal Reports, Office 365 (SharePoint + Exchange Online), Windows Azure, GAMP 5, Microsoft Teams, Microsoft Intune (MDM/MAM), Microsoft Defender for Cloud (EDR), Atlassian Jira Software, Jira Service Management (CMDB), Azure Recovery Services, Azure DevOps, GitHub, .NET Framework, .NET Core, C#, PowerShell, Arduino UNO, Remote Desktop Services + RemoteApp, Azure VPN client, Microsoft Fabric, Microsoft 365 Copilot, Copilot Studio, IIS, Richo (servicio de impresión).

## Verificación

- `yaml.safe_load` parsea ambos archivos sin errores.
- Cantidad y orden espejados entre ES y EN (37 cada uno).
- `bundle exec jekyll build` dentro de un contenedor `ruby:3.2` finaliza sin warnings; `_site/index.html` y `_site/es/index.html` renderizan exactamente 37 project items, en orden newest-first.
- El em-dash `&mdash;` se preserva en las 37 durations.
- No se modificaron `_config.yml`, `_layouts/` ni `strings.yml`: el cambio es 100% en la capa de datos.

## Notas

- La modificación preexistente en `Gemfile.lock` (no relacionada con este PR) queda fuera del commit.
- Decisión de redacción: `description` en una sola oración en pretérito, sin nombres propios de personas (regla ya establecida en el repo).
- Decisión de orden: el layout existente `resume-i18n.html` renderiza los `resume-item` en el orden de la lista, así que la ordenación newest-first se obtiene naturalmente con la lista en ese orden, sin tocar el layout.