### PR TITLE
Alinear resúmenes de experiencia con proyectos + acortar título del puesto

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: "Christian Grimberg - Resume / CV"
-description: "Professional resume of Christian Grimberg - Head of Systems & Solutions Architect"
+description: "Professional resume of Christian Grimberg - Head of Systems"
 baseurl: "" # for GitHub Pages user site
 url: "https://christiangrimberg.github.io"
 

--- a/_data/en/experience.yml
+++ b/_data/en/experience.yml
@@ -1,6 +1,6 @@
 # Professional Experience
 - company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
-  position: "Head of Systems & Solutions Architect"
+  position: "Head of Systems"
   duration: "February 2014 &mdash; Present"
   summary: >
     Alignment of technology strategy with business goals. Conceptual

--- a/_data/en/experience.yml
+++ b/_data/en/experience.yml
@@ -11,9 +11,9 @@
     Building of high-performance teams through coaching and mentoring.
     Leadership of software implementation projects. Participation in
     the definition of strategy in agreement with the different business
-    units. Project administration under agile methodologies such as
-    SCRUM, Kanban Boards, Lean, Pair Programming, and Roadmap Projection.
-    Experience in roles such as Product Owner and Scrum Master.
+    units. Project administration under the SCRUM Framework with
+    two-week sprints. Experience in roles such as Product Owner
+    and Scrum Master.
 
 - company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
   position: "Systems Supervisor"
@@ -22,7 +22,6 @@
     Coordination of the Systems area, supporting the alignment of
     technology strategy with business goals. Hands-on supervision of
     the organization's technology infrastructure and IT processes.
-    Administration of processes under pharmaceutical quality standards.
     Coordination of software implementation projects and technical
     suppliers. Foundation of DevOps practices and collaboration
     patterns later scaled into the Head of Systems role.

--- a/_data/en/strings.yml
+++ b/_data/en/strings.yml
@@ -1,7 +1,7 @@
 # UI strings in English
 site_title: "Christian Grimberg - Resume"
-job_title: "Head of Systems & Solutions Architect"
-executive_summary: "<p>Head of Systems and Solutions Architect with over 20 years of experience at Laboratorios Novocap S.A. in the pharmaceutical industry. Focused on continuous improvement through the use of technology and on delivering solutions that maximize value for the organization. Specialized in Cloud and hybrid infrastructure, network and server administration, and agile project leadership.</p>"
+job_title: "Head of Systems"
+executive_summary: "<p>Head of Systems with over 20 years of experience at Laboratorios Novocap S.A. in the pharmaceutical industry. Focused on continuous improvement through the use of technology and on delivering solutions that maximize value for the organization. Specialized in Cloud and hybrid infrastructure, network and server administration, and agile project leadership.</p>"
 contact_button: "Contact me"
 not_looking: "I'm not looking for work right now."
 

--- a/_data/es/experience.yml
+++ b/_data/es/experience.yml
@@ -14,10 +14,9 @@
     coaching y mentoring permanente. Liderazgo de Proyectos en
     implementación de Software. Participación en la definición de la
     estrategia de común acuerdo con las diferentes unidades de
-    negocio. Administración de Proyectos bajo metodologías ágiles
-    tales como Framework SCRUM, Kanban Boards, Lean, Pair Programming
-    y Proyección de Roadmap. Experiencia en roles como Product Owner
-    y Scrum Master.
+    negocio. Administración de Proyectos bajo el Framework SCRUM
+    con sprints de dos semanas. Experiencia en roles como Product
+    Owner y Scrum Master.
 
 - company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
   position: "Supervisor de Sistemas"
@@ -26,12 +25,11 @@
     Coordinación del área de Sistemas, apoyando el alineamiento de
     la estrategia tecnológica con los objetivos del negocio.
     Supervisión operativa de la infraestructura tecnológica y de
-    los procesos de IT de la organización. Administración de
-    procesos bajo el cumplimiento de estándares de calidad
-    farmacéutica. Coordinación de proyectos de implementación de
-    Software y de proveedores técnicos. Puesta en marcha de las
-    prácticas de DevOps y de los esquemas de colaboración que
-    luego se consolidarían en el rol de Jefe de Sistemas.
+    los procesos de IT de la organización. Coordinación de proyectos
+    de implementación de Software y de proveedores técnicos. Puesta
+    en marcha de las prácticas de DevOps y de los esquemas de
+    colaboración que luego se consolidarían en el rol de Jefe de
+    Sistemas.
 
 - company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
   position: "Operador de Mantenimiento - Técnico Electromecánico"

--- a/_data/es/experience.yml
+++ b/_data/es/experience.yml
@@ -1,6 +1,6 @@
 # Experiencia Profesional
 - company: "Laboratorios Novocap S.A. (Buenos Aires, Argentina)"
-  position: "Jefe de Sistemas & Arquitecto de Soluciones"
+  position: "Jefe de Sistemas"
   duration: "Febrero 2014 &mdash; Presente"
   summary: >
     Alineamiento de la estrategia tecnológica de acuerdo con los

--- a/_data/es/strings.yml
+++ b/_data/es/strings.yml
@@ -1,7 +1,7 @@
 # UI strings in Spanish
 site_title: "Christian Grimberg - Curriculum Vitae"
-job_title: "Jefe de Sistemas & Arquitecto de Soluciones"
-executive_summary: "<p>Jefe de Sistemas y Arquitecto de Soluciones con una trayectoria de más de 20 años en Laboratorios Novocap S.A. dentro de la Industria Farmacéutica, enfocado en la mejora continua a través del uso de la tecnología y en brindar soluciones que maximicen el valor para la organización. Especializado en infraestructura Cloud e híbrida, administración de redes y servidores, y liderazgo de proyectos bajo metodologías ágiles.</p>"
+job_title: "Jefe de Sistemas"
+executive_summary: "<p>Jefe de Sistemas con una trayectoria de más de 20 años en Laboratorios Novocap S.A. dentro de la Industria Farmacéutica, enfocado en la mejora continua a través del uso de la tecnología y en brindar soluciones que maximicen el valor para la organización. Especializado en infraestructura Cloud e híbrida, administración de redes y servidores, y liderazgo de proyectos bajo metodologías ágiles.</p>"
 contact_button: "Contáctame"
 not_looking: "No estoy buscando trabajo en este momento."
 


### PR DESCRIPTION
## Resumen

Dos objetivos:

1. **Alinear los resúmenes de Experiencia con la sección de Proyectos Destacados**, para que ninguno afirme algo que la lista de proyectos no respalde.
2. **Acortar el título largo del puesto** a su forma esencial, en todos los lugares del sitio donde aparece.

### Cambios de coherencia (Experiencia ↔ Proyectos Destacados)

El resumen anterior de *Jefe de Sistemas & Arquitecto de Soluciones* enumeraba cuatro metodologías ágiles (Kanban Boards, Lean, Pair Programming) y una práctica de *Roadmap Projection* que no se reflejan en ninguna entrada de Proyecto Destacado. El único proyecto que menciona los roles de Scrum + Product Owner + Scrum Master es el de *DevOps backup and data retention system*. Se recortó la lista de metodologías a lo efectivamente respaldado por el corpus de proyectos.

El resumen anterior de *Supervisor de Sistemas* mencionaba trabajo con *pharmaceutical quality standards*, pero el proyecto de GAMP 5 / validación de sistemas computarizados pertenece claramente al período de Jefe de Sistemas (2014–Presente), no al de Supervisor (2009–2014). Se eliminó esa afirmación.

Aplicado en espejo tanto en EN como en ES.

### Acortamiento del título del puesto

Se reemplazó cada aparición del título largo por la forma corta:

| Archivo | Antes | Después |
|---|---|---|
| `_data/es/experience.yml` (position) | Jefe de Sistemas & Arquitecto de Soluciones | Jefe de Sistemas |
| `_data/en/experience.yml` (position) | Head of Systems & Solutions Architect | Head of Systems |
| `_data/es/strings.yml` (job_title + executive_summary) | (misma forma larga) | Jefe de Sistemas |
| `_data/en/strings.yml` (job_title + executive_summary) | (misma forma larga) | Head of Systems |
| `_config.yml` (meta description) | (misma forma larga) | Head of Systems |

### Commits (uno por archivo, por convención del repo)

- `66b473c` fix(cv): recortar lista de metodologías ágiles y quitar calidad farmacéutica del Supervisor (ES)
- `1ff8368` fix(cv): recortar lista de metodologías ágiles y quitar calidad farmacéutica del Supervisor (EN)
- `bf202a9` fix(cv): acortar job_title a 'Jefe de Sistemas' en strings ES
- `4ce2b96` fix(cv): acortar job_title a 'Head of Systems' en strings EN
- `23e0eac` fix(cv): acortar position a 'Jefe de Sistemas' en experience ES
- `ff41537` fix(cv): acortar position a 'Head of Systems' en experience EN
- `7b26202` fix(cv): acortar meta description a 'Head of Systems'

## Verificación

`scripts/verify-experience.py` luego de la PR:

- 13 chequeos estructurales OK: orden descendente, contigüidad en cada límite de rol Novocap, y paridad total EN ↔ ES (cantidad de entradas, meses/años de inicio, mapeo 1 a 1 de puestos).
- 4 FAILs por huecos de contigüidad entre los roles anteriores a Novocap (Repair Banfield ↔ Cyber ZiOn, Cyber ZiOn ↔ CNC Operator). Son **roles paralelos preexistentes** ya presentes en `main` antes de esta PR (verificado corriendo el verificador sobre un checkout limpio de `main`); no fueron introducidos por este cambio. El verificador estricto los marca, pero la línea de tiempo paralela es real según el historial del usuario.
