### PR TITLE
Habilitar actualizaciones de Dependabot para GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@
 # Groups Bundler updates into a single weekly PR so changes land atomically
 # instead of the historical one-PR-per-gem pattern (which produced #4/#5
 # cross-conflicts on the json line in Gemfile.lock).
+# Note: the "Re-run Dependabot checks" button appears automatically on every
+# PR opened by Dependabot (no config knob needed). After merging this PR,
+# trigger it once on PR #22's timeline to surface any pending bumps
+# (notably actions/checkout@v4 → v5) without waiting for the weekly schedule.
 version: 2
 updates:
   - package-ecosystem: "bundler"
@@ -21,5 +25,28 @@ updates:
     labels:
       - "dependencies"
       - "ruby"
+      - "automated"
+    commit-message:
+      prefix: ":arrow_up:"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Group all non-major bumps into a single PR
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+    # Keep major bumps as standalone PRs so they get explicit review
+    # (default behavior when groups are defined but no match)
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "ci"
+      - "automated"
     commit-message:
       prefix: ":arrow_up:"


### PR DESCRIPTION
## Resumen
Agrega un bloque `github-actions` a `.github/dependabot.yml` para que Dependabot proponga PRs de actualización de las actions usadas en `.github/workflows/jekyll.yml` (`actions/checkout`, `ruby/setup-ruby`, `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`). También agrega los labels `automated` y `ci` para distinguir PRs automáticos en el dashboard.

## Motivación
El repo solo tenía configurado el ecosistema `bundler`, así que Dependabot no estaba proponiendo actualizaciones para las GitHub Actions del workflow. `actions/checkout` ya va por la rama `v5` (la rama `v4` quedó en estado de deprecation y dejó de recibir fixes de seguridad).

Además, los PRs automáticos de Dependabot van a parar al label `dependencies`, que se vuelve ruidoso si más adelante se suman más ecosystems (npm, docker, etc.). Se agregan dos labels estándar:
- `automated` (en ambos bloques): convención OSS para marcar PRs sin necesidad de review funcional.
- `ci` (solo en `github-actions`): distingue infra-CI de deps de Ruby, que ya tiene su propio label `ruby`.

## Cambios
- Bloque nuevo con `package-ecosystem: "github-actions"` en `.github/dependabot.yml`.
- Mismo schedule semanal que `bundler` (lunes) para evitar días distintos de ruido.
- Misma política de agrupado: minor y patch en un solo PR, major como PRs separados para review explícito.
- Labels: `dependencies` + `github-actions` + `ci` + `automated`.
- Labels del bloque bundler extendido: `dependencies` + `ruby` + `automated`.

## Sobre el trigger manual
**No hay un campo YAML `manualy-run` ni equivalente** en el schema oficial de Dependabot (verificado contra `dependabot-options-reference.md` del repo `github/docs`). Sin embargo, **el botón "Re-run Dependabot checks" aparece automáticamente en la timeline de cada PR abierto por Dependabot**, sin config. Después de mergear este PR:
1. El primer ciclo semanal (lunes) abrirá los PRs pendientes (probablemente `actions/checkout@v4 → v5`).
2. Si querés acelerar: una vez mergeado, hace click en "Re-run Dependabot checks" sobre este mismo PR #22 desde la UI para forzar un re-escaneo inmediato.

## Plan de prueba
- [ ] Verificar que el YAML sigue siendo válido (GitHub lo reporta en el run de Dependabot tras el merge).
- [ ] Confirmar que el primer PR de Dependabot para GitHub Actions usa los labels correctos: `dependencies`, `github-actions`, `ci`, `automated`.