### PR TITLE
Corregir referencia a PR #22 en comentario de dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,10 @@
 # instead of the historical one-PR-per-gem pattern (which produced #4/#5
 # cross-conflicts on the json line in Gemfile.lock).
 # Note: the "Re-run Dependabot checks" button appears automatically on every
-# PR opened by Dependabot (no config knob needed). After merging this PR,
-# trigger it once on PR #22's timeline to surface any pending bumps
-# (notably actions/checkout@v4 → v5) without waiting for the weekly schedule.
+# PR opened by Dependabot (no config knob needed). To force an out-of-band
+# scan without waiting for the weekly schedule, click that button on any
+# Dependabot PR's timeline (e.g. once the first Actions-bump PR opens, you
+# can re-trigger it to surface additional pending bumps).
 version: 2
 updates:
   - package-ecosystem: "bundler"


### PR DESCRIPTION
## Resumen
Actualiza el comentario al tope de `.github/dependabot.yml` que decía "trigger it once on PR #22's timeline". Como el PR #22 ya está mergeado y cerrado, esa instrucción queda obsoleta al instante. Se reemplaza por una referencia genérica al botón en la timeline de cualquier PR futuro de Dependabot.

## Cambio
- Solo comentarios (4 líneas modificadas, 0 líneas de config tocadas).
- Diff: 4 insertions(+), 3 deletions(-).

## Por qué
Detecté el issue justo después de mergear #22: el apuntaba a un PR específico que dejó de existir al merge. Es un fix trivial pero importante para que el archivo siga siendo una guía útil para vos cuando vuelvas a leerlo en 6 meses.

## Plan de prueba
- [ ] Verificar visualmente que el comentario es genérico y no menciona ningún PR específico.
- [ ] Merge (squash) — el cambio es seguro, no toca schema ni config.